### PR TITLE
test for signal receiver

### DIFF
--- a/gob/receivers_test.go
+++ b/gob/receivers_test.go
@@ -6,6 +6,10 @@ import (
 	"github.com/doubledutch/mux/tests"
 )
 
-func TestReceiver(t *testing.T) {
-	tests.Receiver(t, new(Pool))
+func TestStringReceiver(t *testing.T) {
+	tests.StringReceiver(t, new(Pool))
+}
+
+func TestSignalReceiver(t *testing.T) {
+	tests.SignalReceiver(t, new(Pool))
 }

--- a/json/receivers_test.go
+++ b/json/receivers_test.go
@@ -6,6 +6,10 @@ import (
 	"github.com/doubledutch/mux/tests"
 )
 
-func TestReceiver(t *testing.T) {
-	tests.Receiver(t, new(Pool))
+func TestStringReceiver(t *testing.T) {
+	tests.StringReceiver(t, new(Pool))
+}
+
+func TestSignalReceiver(t *testing.T) {
+	tests.SignalReceiver(t, new(Pool))
 }

--- a/tests/conn.go
+++ b/tests/conn.go
@@ -13,7 +13,7 @@ import (
 // Lager returns a new test Lager
 func Lager() lager.Lager {
 	return lager.NewLogLager(&lager.LogConfig{
-		Levels: lager.LevelsFromString(""),
+		Levels: lager.LevelsFromString(os.Getenv("LOG_LEVELS")),
 		Output: os.Stderr,
 	})
 }


### PR DESCRIPTION
we have a explicit signal receiver to decode os.Signal into syscall.Signal, for use with signal.Notify.
